### PR TITLE
Untested proof on concept for more pathlike APIs

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_client.py
@@ -633,6 +633,11 @@ class BlobClient(StorageAccountHostsMixin):  # pylint: disable=too-many-public-m
         options.update(kwargs)
         return options
 
+    def open(self, mode='r'):
+        if mode == 'r':
+            return self.download_blob()
+        raise ValueError('Anything other than read-only streams is not yet implemented...')
+
     @distributed_trace
     def download_blob(self, offset=None, length=None, **kwargs):
         # type: (Optional[int], Optional[int], bool, **Any) -> Iterable[bytes]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/blob_service_client.py
@@ -285,6 +285,9 @@ class BlobServiceClient(StorageAccountHostsMixin):
         except StorageErrorException as error:
             process_storage_error(error)
 
+    def __div__(self, pathsegment):
+        return self.get_container_client(pathsegment)
+
     @distributed_trace
     def get_service_stats(self, **kwargs): # type: ignore
         # type: (**Any) -> Dict[str, Any]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/container_client.py
@@ -175,6 +175,16 @@ class ContainerClient(StorageAccountHostsMixin):
             quote(container_name),
             self._query_str)
 
+    def __div__(self, pathsegment):
+        # type: (str) -> BlobClient
+        return self.get_blob_client(pathsegment)
+
+    def mkdir(self):
+        # type: () -> ContainerClient
+        """Create the container that the current client represents
+        """
+        return self.create_container()
+
     @classmethod
     def from_connection_string(
             cls, conn_str,  # type: str


### PR DESCRIPTION
Thoughts on an API that looks like this:

```python
root = BlobStorageClient(...)

blob = root / 'thecontainer' / 'theblob.html'
with blob.open('r') as b:
    print(b.read())

not_yet_created_container = root / 'newcontainer'
not_yet_created_container.mkdir()
``` 
?

I think we are almost there. 
